### PR TITLE
[FIX] Разрешение экрана

### DIFF
--- a/Content.Shared/CCVar/CCVars.Viewport.cs
+++ b/Content.Shared/CCVar/CCVars.Viewport.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Configuration;
+﻿﻿using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 
@@ -23,10 +23,10 @@ public sealed partial class CCVars
         CVarDef.Create("viewport.minimum_width", 15, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> ViewportMaximumWidth =
-        CVarDef.Create("viewport.maximum_width", 21, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("viewport.maximum_width", 29, CVar.REPLICATED | CVar.SERVER); //16:9
 
     public static readonly CVarDef<int> ViewportWidth =
-        CVarDef.Create("viewport.width", 21, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("viewport.width", 29, CVar.CLIENTONLY | CVar.ARCHIVE); //16:9
 
     public static readonly CVarDef<bool> ViewportVerticalFit =
         CVarDef.Create("viewport.vertical_fit", true, CVar.CLIENTONLY | CVar.ARCHIVE);


### PR DESCRIPTION
## Описание ПРа
Более лучшее отображение игры в разрешении 16:9

## Почему / Баланс
Разрешение 16:9 для мониторов на 16:9, Тобишь более правильный полный экран

**Чейнджлог**
Починка отображения рендеринга, большое спасибо Schrodinger-у за помощь в этом

:cl:
- fix: Починил разрешение 16:9